### PR TITLE
Accessibility updates for paginated carousels

### DIFF
--- a/src/components/carousel-item/carousel-item.component.ts
+++ b/src/components/carousel-item/carousel-item.component.ts
@@ -20,7 +20,6 @@ export default class SlCarouselItem extends ShoelaceElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.setAttribute('role', 'group');
   }
 
   render() {

--- a/src/components/carousel/carousel.component.ts
+++ b/src/components/carousel/carousel.component.ts
@@ -367,7 +367,15 @@ export default class SlCarousel extends ShoelaceElement {
     this.getSlides({ excludeClones: false }).forEach((slide, index) => {
       slide.classList.remove('--in-view');
       slide.classList.remove('--is-active');
+      slide.setAttribute('role', 'group');
       slide.setAttribute('aria-label', this.localize.term('slideNum', index + 1));
+
+      if (this.pagination) {
+        slide.setAttribute('role', 'tabpanel');
+        slide.removeAttribute('aria-label');
+        slide.setAttribute('aria-labelledby', `tab-${index + 1}`);
+        slide.setAttribute('id', `slide-${index + 1}`);
+      }
 
       if (slide.hasAttribute('data-clone')) {
         slide.remove();
@@ -611,7 +619,7 @@ export default class SlCarousel extends ShoelaceElement {
           : ''}
         ${this.pagination
           ? html`
-              <div part="pagination" role="tablist" class="carousel__pagination" aria-controls="scroll-container">
+              <div part="pagination" role="tablist" class="carousel__pagination">
                 ${map(range(pagesCount), index => {
                   const isActive = index === currentPage;
                   return html`
@@ -622,6 +630,8 @@ export default class SlCarousel extends ShoelaceElement {
                         'carousel__pagination-item--active': isActive
                       })}"
                       role="tab"
+                      id="tab-${index + 1}"
+                      aria-controls="slide-${index + 1}"
                       aria-selected="${isActive ? 'true' : 'false'}"
                       aria-label="${this.localize.term('goToSlide', index + 1, pagesCount)}"
                       tabindex=${isActive ? '0' : '-1'}


### PR DESCRIPTION
This PR addresses the following [discussion](https://github.com/shoelace-style/shoelace/discussions/2303): 

When pagination is enabled:
- Add `role="tabpanel"` to each `sl-carousel-item`.
- Add an `id` to each `sl-carousel-item` that can be referenced by the `aria-controls` attribute on each tab.
- Remove `aria-controls` from the pagination part, adding it to each tab element instead, and populating it with the corresponding `id` of each `tabpanel` .
- Add an `id` to each tab.
- Add `aria-labelledby` to each `sl-carousel-item` and populate it with the `id` of the corresponding tab.

I'm willing to try creating a PR for this.

References:
- MDN: [tab role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role)
- MDN: [tab role example](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#example)
- MDN: [tab panel role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tabpanel_role)
- MDN: [tablist role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role)
- MDN: [aria-controls](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls)